### PR TITLE
1. fix pin order in generated netlists; 2. add pwlFile in spectre.cpp dictionary

### DIFF
--- a/include/cbag/netlist/core.h
+++ b/include/cbag/netlist/core.h
@@ -125,9 +125,9 @@ void write_cv_content(Stream &stream, const sch::cellview_info &info,
             auto inst_ast = cbag::util::parse_cdba_name_unit(inst_name);
             auto n = inst_ast.size();
             auto term_net_vec = term_net_vec_t();
-            split_array_inst_nets(term_net_vec, inst_name, n, inst->connections, cv_info.in_terms);
             split_array_inst_nets(term_net_vec, inst_name, n, inst->connections, cv_info.out_terms);
             split_array_inst_nets(term_net_vec, inst_name, n, inst->connections, cv_info.io_terms);
+            split_array_inst_nets(term_net_vec, inst_name, n, inst->connections, cv_info.in_terms);
 
             for (decltype(n) inst_idx = 0; inst_idx < n; ++inst_idx) {
                 if (flat && cv_info.cv_ptr) {

--- a/src/cbag/netlist/cdl.cpp
+++ b/src/cbag/netlist/cdl.cpp
@@ -175,14 +175,14 @@ void traits::nstream<cdl_stream>::write_cv_header(type &stream, const std::strin
     b2 << "*.PININFO";
     if (stream.square_bracket()) {
         auto tag = spirit::namespace_verilog{};
-        cdl::get_cv_term_bits(b, b2, info.in_terms, ":I", tag);
         cdl::get_cv_term_bits(b, b2, info.out_terms, ":O", tag);
         cdl::get_cv_term_bits(b, b2, info.io_terms, ":B", tag);
+        cdl::get_cv_term_bits(b, b2, info.in_terms, ":I", tag);
     } else {
         auto tag = spirit::namespace_cdba{};
-        cdl::get_cv_term_bits(b, b2, info.in_terms, ":I", tag);
         cdl::get_cv_term_bits(b, b2, info.out_terms, ":O", tag);
         cdl::get_cv_term_bits(b, b2, info.io_terms, ":B", tag);
+        cdl::get_cv_term_bits(b, b2, info.in_terms, ":I", tag);
     }
 
     // write definition line

--- a/src/cbag/netlist/spectre.cpp
+++ b/src/cbag/netlist/spectre.cpp
@@ -162,6 +162,7 @@ std::unordered_map<std::string, std::string> new_prop_name_map() {
     prop_map["pacp"] = "pacphase";
     prop_map["per"] = "period";
     prop_map["pw"] = "width";
+    prop_map["pwlFile"] = "file";
     prop_map["rc"] = "rclosed";
     prop_map["ro"] = "ropen";
     prop_map["srcType"] = "type";
@@ -246,9 +247,9 @@ void traits::nstream<spectre_stream>::write_cv_header(type &stream, const std::s
         lstream b;
         b << "subckt";
         b << name;
-        spectre::get_cv_pins(b, info.in_terms);
         spectre::get_cv_pins(b, info.out_terms);
         spectre::get_cv_pins(b, info.io_terms);
+        spectre::get_cv_pins(b, info.in_terms);
 
         // write definition line
         b.to_file(stream, spirit::namespace_spectre{});

--- a/src/cbag/netlist/verilog.cpp
+++ b/src/cbag/netlist/verilog.cpp
@@ -183,12 +183,12 @@ void write_cv_header(verilog_stream &stream, const std::string &name,
 
     bool has_prev_term = false;
     auto &term_net_attrs = info.term_net_attrs;
-    write_cv_ports(stream, info.in_terms, has_prev_term, "    input ", term_net_attrs, cv,
-                   wrap_conn_list_ptr, used_names_ptr, sup_val_ptr);
     write_cv_ports(stream, info.out_terms, has_prev_term, "    output", term_net_attrs, cv,
                    wrap_conn_list_ptr, used_names_ptr, sup_val_ptr);
     write_cv_ports(stream, info.io_terms, has_prev_term, "    inout ", term_net_attrs, cv,
                    wrap_conn_list_ptr, used_names_ptr, sup_val_ptr, true);
+    write_cv_ports(stream, info.in_terms, has_prev_term, "    input ", term_net_attrs, cv,
+                   wrap_conn_list_ptr, used_names_ptr, sup_val_ptr);
     if (has_prev_term)
         stream << '\n';
     stream << ");";


### PR DESCRIPTION
The line "auCdlCDFPinCntrl = t" line in the ".simrc" file in the workspace forces Virtuoso to maintain the pin order of "output - inputOutput - input" in all Virtuoso generated netlists. However the C++ netlister in BAG was previously doing the pin order of "I - O - I/O". This discrepancy stays hidden if BAG generated designs are used in BAG simulation framework. However if Virtuoso generated netlists are used in BAG simulation framework, the pin order discrepancy has to be fixed. This merge request, along with the corresponding merge request in BAG_framework, fixes the pin order to the correct "O - I/O - I" format across all BAG generated netlists.