### PR TITLE
Adding includes and inlines to fix compilation issues

### DIFF
--- a/include/cbag/common/typedefs.h
+++ b/include/cbag/common/typedefs.h
@@ -49,6 +49,7 @@ limitations under the License.
 
 #include <cstdint>
 #include <tuple>
+#include <limits>
 
 namespace cbag {
 

--- a/include/cbag/layout/lp_lookup.h
+++ b/include/cbag/layout/lp_lookup.h
@@ -48,6 +48,7 @@ limitations under the License.
 #define CBAG_COMMON_LP_LOOKUP_H
 
 #include <unordered_map>
+#include <optional>
 
 #include <cbag/common/typedefs.h>
 

--- a/include/cbag/spirit/name_unit_def.h
+++ b/include/cbag/spirit/name_unit_def.h
@@ -66,7 +66,7 @@ namespace parser {
 
 name_unit_type const name_unit = "name_unit";
 
-auto check_str = [](auto &ctx) { x3::_pass(ctx) = (std::isalpha(x3::_attr(ctx).at(0)) != 0); };
+inline auto check_str = [](auto &ctx) { x3::_pass(ctx) = (std::isalpha(x3::_attr(ctx).at(0)) != 0); };
 
 /** A string with no spaces, parentheses, angle brackets, colon, commas, or stars.
  */

--- a/include/cbag/spirit/range_def.h
+++ b/include/cbag/spirit/range_def.h
@@ -62,13 +62,13 @@ namespace spirit {
 namespace parser {
 
 // after parsing start, set default values of stop and step
-auto init_range = [](auto &ctx) {
+inline auto init_range = [](auto &ctx) {
     x3::_val(ctx).stop = x3::_attr(ctx);
     x3::_val(ctx).step = 1;
 };
 
 // make sure value is not 0
-auto check_zero = [](auto &ctx) { x3::_pass(ctx) = (x3::_attr(ctx) != 0); };
+inline auto check_zero = [](auto &ctx) { x3::_pass(ctx) = (x3::_attr(ctx) != 0); };
 
 range_type const range = "range";
 


### PR DESCRIPTION
Adding fixes that appear when migrating to GCC-11.
- Fixing "include" statements for certain files.
- Adding "inline" for functions in header files.

This has been tested with GCC-11 on Ubuntu 22.04 and GCC-8 on Ubuntu 20.04.